### PR TITLE
Return on "next()"

### DIFF
--- a/lib/connect-cors.js
+++ b/lib/connect-cors.js
@@ -47,8 +47,8 @@ module.exports = function corsSetup(options) {
 
     return function corsHandle(req, res, next) {
 
-        if (!req.headers.origin) next(); // spec: 5.1.1
-        if (req.method === 'OPTIONS') next(); // TODO process preflight requests
+        if (!req.headers.origin) return next(); // spec: 5.1.1
+        if (req.method === 'OPTIONS') return next(); // TODO process preflight requests
 
         var origin = req.headers.origin,
             resource = url.parse(req.url).pathname,


### PR DESCRIPTION
There's a simple error I ran over while trying to use this lib. You must `return next()` instead of simply `next()` so that the middleware logic doesn't keep on going.

Please merge and push an npm update, thanks!
